### PR TITLE
Fix #2: 无法提交评论

### DIFF
--- a/blog-backend/src/main/java/com/blog/config/GlobalExceptionHandler.java
+++ b/blog-backend/src/main/java/com/blog/config/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.blog.config;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getDefaultMessage())
+                .findFirst()
+                .orElse("参数校验失败");
+        return ResponseEntity.badRequest().body(Map.of("message", message));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of("message", ex.getMessage()));
+    }
+}

--- a/blog-frontend/src/views/ArticleDetail.vue
+++ b/blog-frontend/src/views/ArticleDetail.vue
@@ -29,6 +29,7 @@
         <div class="form-item">
           <textarea v-model="commentForm.content" placeholder="写下你的评论..." rows="4" required maxlength="2000"></textarea>
         </div>
+        <div v-if="commentError" class="comment-error">{{ commentError }}</div>
         <div class="form-actions">
           <button type="submit" class="btn btn-primary" :disabled="submitting">
             {{ submitting ? '提交中...' : '发表评论' }}
@@ -76,6 +77,7 @@ const article = ref(null)
 const comments = ref([])
 const submitting = ref(false)
 const commentForm = ref({ nickname: '', email: '', content: '' })
+const commentError = ref('')
 const md = new MarkdownIt({ html: true, linkify: true, typographer: true })
 
 const renderedContent = computed(() => {
@@ -96,10 +98,13 @@ async function loadComments() {
 async function submitComment() {
   if (!commentForm.value.nickname.trim() || !commentForm.value.content.trim()) return
   submitting.value = true
+  commentError.value = ''
   try {
     await api.post(`/articles/${route.params.id}/comments`, commentForm.value)
     commentForm.value = { nickname: commentForm.value.nickname, email: commentForm.value.email, content: '' }
     await loadComments()
+  } catch (err) {
+    commentError.value = err.response?.data?.message || '评论提交失败，请稍后再试'
   } finally {
     submitting.value = false
   }
@@ -222,6 +227,12 @@ onMounted(async () => {
   display: flex;
   justify-content: flex-end;
   margin-top: 12px;
+}
+
+.comment-error {
+  color: var(--color-danger, #e53e3e);
+  font-size: 14px;
+  margin-bottom: 8px;
 }
 
 .comment-list { display: flex; flex-direction: column; gap: 0; }


### PR DESCRIPTION
Fixes #2

## Summary
- 前端 submitComment 添加 catch 错误处理，提交失败时显示错误信息
- 后端添加 GlobalExceptionHandler 处理参数校验和业务逻辑异常，返回友好 JSON 错误
- 评论表单中展示错误提示

## Test plan
- [ ] 提交评论验证正常提交成功
- [ ] 验证异常情况下错误信息正确展示