### PR TITLE
Fix #3: 留言管理

### DIFF
--- a/blog-backend/src/main/java/com/blog/controller/CommentController.java
+++ b/blog-backend/src/main/java/com/blog/controller/CommentController.java
@@ -29,6 +29,16 @@ public class CommentController {
         return ResponseEntity.ok(comment);
     }
 
+    @GetMapping("/api/admin/comments")
+    public List<Comment> listAll() {
+        return commentService.findAll();
+    }
+
+    @PutMapping("/api/admin/comments/{id}/toggle-visible")
+    public ResponseEntity<Comment> toggleVisible(@PathVariable Long id) {
+        return ResponseEntity.ok(commentService.toggleVisible(id));
+    }
+
     @DeleteMapping("/api/admin/comments/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         commentService.deleteById(id);

--- a/blog-backend/src/main/java/com/blog/entity/Comment.java
+++ b/blog-backend/src/main/java/com/blog/entity/Comment.java
@@ -28,6 +28,9 @@ public class Comment {
     @Column(name = "article_id", insertable = false, updatable = false)
     private Long articleId;
 
+    @Column(nullable = false)
+    private Boolean visible = true;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
@@ -47,6 +50,8 @@ public class Comment {
     public Article getArticle() { return article; }
     public void setArticle(Article article) { this.article = article; }
     public Long getArticleId() { return articleId; }
+    public Boolean getVisible() { return visible; }
+    public void setVisible(Boolean visible) { this.visible = visible; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
 }

--- a/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
+++ b/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleIdOrderByCreatedAtDesc(Long articleId);
+    List<Comment> findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(Long articleId);
+    List<Comment> findAllByOrderByCreatedAtDesc();
 }

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -20,7 +20,18 @@ public class CommentService {
     }
 
     public List<Comment> findByArticleId(Long articleId) {
-        return commentRepository.findByArticleIdOrderByCreatedAtDesc(articleId);
+        return commentRepository.findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(articleId);
+    }
+
+    public List<Comment> findAll() {
+        return commentRepository.findAllByOrderByCreatedAtDesc();
+    }
+
+    @Transactional
+    public Comment toggleVisible(Long id) {
+        Comment comment = commentRepository.findById(id).orElseThrow();
+        comment.setVisible(!comment.getVisible());
+        return commentRepository.save(comment);
     }
 
     @Transactional

--- a/blog-frontend/src/router/index.js
+++ b/blog-frontend/src/router/index.js
@@ -14,7 +14,8 @@ const routes = [
       { path: 'articles/new', component: () => import('../views/admin/ArticleEdit.vue') },
       { path: 'articles/:id/edit', component: () => import('../views/admin/ArticleEdit.vue') },
       { path: 'categories', component: () => import('../views/admin/CategoryList.vue') },
-      { path: 'tags', component: () => import('../views/admin/TagList.vue') }
+      { path: 'tags', component: () => import('../views/admin/TagList.vue') },
+      { path: 'comments', component: () => import('../views/admin/CommentList.vue') }
     ]
   }
 ]

--- a/blog-frontend/src/views/admin/CommentList.vue
+++ b/blog-frontend/src/views/admin/CommentList.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <div class="page-header">
+      <h2>留言管理</h2>
+    </div>
+
+    <div class="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>昵称</th>
+            <th>内容</th>
+            <th>时间</th>
+            <th>状态</th>
+            <th style="width: 160px">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in comments" :key="item.id" :class="{ 'row-hidden': !item.visible }">
+            <td class="comment-nickname">{{ item.nickname }}</td>
+            <td class="comment-content">{{ item.content }}</td>
+            <td class="text-muted">{{ item.createdAt?.substring(0, 10) }}</td>
+            <td>
+              <span :class="['status-badge', item.visible ? 'status-visible' : 'status-hidden']">
+                {{ item.visible ? '展示中' : '已隐藏' }}
+              </span>
+            </td>
+            <td>
+              <div class="action-btns">
+                <button class="btn btn-ghost btn-sm" @click="handleToggle(item.id)">
+                  {{ item.visible ? '隐藏' : '展示' }}
+                </button>
+                <button class="btn btn-ghost btn-sm btn-delete" @click="handleDelete(item.id)">删除</button>
+              </div>
+            </td>
+          </tr>
+          <tr v-if="comments.length === 0">
+            <td colspan="5" class="empty-row">暂无留言</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../../api'
+
+const comments = ref([])
+
+async function loadComments() {
+  const { data } = await api.get('/admin/comments')
+  comments.value = data
+}
+
+async function handleToggle(id) {
+  await api.put(`/admin/comments/${id}/toggle-visible`)
+  loadComments()
+}
+
+async function handleDelete(id) {
+  if (!confirm('确定删除该留言？')) return
+  await api.delete(`/admin/comments/${id}`)
+  loadComments()
+}
+
+onMounted(loadComments)
+</script>
+
+<style scoped>
+.page-header { margin-bottom: 24px; }
+.page-header h2 { font-size: 20px; font-weight: 700; }
+
+.table-wrapper {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--color-border-light);
+}
+
+.comment-nickname { font-weight: 500; white-space: nowrap; }
+.comment-content { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.text-muted { color: var(--color-text-muted); font-size: 13px; }
+
+.status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+}
+.status-visible { background: #dcfce7; color: #166534; }
+.status-hidden { background: #fee2e2; color: #991b1b; }
+
+.row-hidden { opacity: 0.6; }
+
+.action-btns { display: flex; gap: 6px; }
+.btn-sm { padding: 5px 12px; font-size: 13px; }
+.btn-delete:hover { color: var(--color-danger); border-color: var(--color-danger); }
+
+.empty-row { text-align: center; color: var(--color-text-muted); padding: 48px 0 !important; }
+</style>

--- a/blog-frontend/src/views/admin/Dashboard.vue
+++ b/blog-frontend/src/views/admin/Dashboard.vue
@@ -17,6 +17,10 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
           标签管理
         </router-link>
+        <router-link to="/admin/comments" class="sidebar-link">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+          留言管理
+        </router-link>
       </nav>
     </aside>
     <section class="admin-content">


### PR DESCRIPTION
Fixes #3

## Summary
- Comment 实体添加 visible 字段控制评论展示
- 公开接口仅返回可见评论
- 后台新增留言管理页面，支持隐藏/展示和删除操作

## Test plan
- [ ] 后台留言管理页面正常显示所有评论
- [ ] 隐藏评论后前台不再展示
- [ ] 删除评论正常工作