### PR TITLE
Fix #4: 将最新文章标题和副标题用中文博客风格替代

### DIFF
--- a/blog-frontend/src/views/Home.vue
+++ b/blog-frontend/src/views/Home.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <header class="page-header">
-      <h1>Latest Posts</h1>
-      <p class="page-subtitle">Thoughts, ideas, and stories</p>
+      <h1>最新文章</h1>
+      <p class="page-subtitle">思考、记录与分享</p>
     </header>
 
     <div v-if="articles.length === 0" class="empty-state">


### PR DESCRIPTION
Fixes #4

## Summary
- 首页标题从 "Latest Posts" 改为 "最新文章"
- 副标题从 "Thoughts, ideas, and stories" 改为 "思考、记录与分享"

## Test plan
- [ ] 首页标题和副标题显示为中文