### PR TITLE
Fix #8: 留言需区分哪篇文章的留言

### DIFF
--- a/blog-backend/src/main/java/com/blog/entity/Comment.java
+++ b/blog-backend/src/main/java/com/blog/entity/Comment.java
@@ -50,6 +50,8 @@ public class Comment {
     public Article getArticle() { return article; }
     public void setArticle(Article article) { this.article = article; }
     public Long getArticleId() { return articleId; }
+    @Transient
+    public String getArticleTitle() { return article != null ? article.getTitle() : null; }
     public Boolean getVisible() { return visible; }
     public void setVisible(Boolean visible) { this.visible = visible; }
     public LocalDateTime getCreatedAt() { return createdAt; }

--- a/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
+++ b/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
@@ -2,11 +2,14 @@ package com.blog.repository;
 
 import com.blog.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleIdOrderByCreatedAtDesc(Long articleId);
     List<Comment> findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(Long articleId);
-    List<Comment> findAllByOrderByCreatedAtDesc();
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.article ORDER BY c.createdAt DESC")
+    List<Comment> findAllWithArticle();
 }

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -24,7 +24,7 @@ public class CommentService {
     }
 
     public List<Comment> findAll() {
-        return commentRepository.findAllByOrderByCreatedAtDesc();
+        return commentRepository.findAllWithArticle();
     }
 
     @Transactional

--- a/blog-frontend/src/views/admin/CommentList.vue
+++ b/blog-frontend/src/views/admin/CommentList.vue
@@ -8,6 +8,7 @@
       <table>
         <thead>
           <tr>
+            <th>文章</th>
             <th>昵称</th>
             <th>内容</th>
             <th>时间</th>
@@ -17,6 +18,7 @@
         </thead>
         <tbody>
           <tr v-for="item in comments" :key="item.id" :class="{ 'row-hidden': !item.visible }">
+            <td class="comment-article">{{ item.articleTitle || '-' }}</td>
             <td class="comment-nickname">{{ item.nickname }}</td>
             <td class="comment-content">{{ item.content }}</td>
             <td class="text-muted">{{ item.createdAt?.substring(0, 10) }}</td>
@@ -35,7 +37,7 @@
             </td>
           </tr>
           <tr v-if="comments.length === 0">
-            <td colspan="5" class="empty-row">暂无留言</td>
+            <td colspan="6" class="empty-row">暂无留言</td>
           </tr>
         </tbody>
       </table>
@@ -78,7 +80,8 @@ onMounted(loadComments)
   border: 1px solid var(--color-border-light);
 }
 
-.comment-nickname { font-weight: 500; white-space: nowrap; }
+.comment-article { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 500; }
+.comment-nickname { white-space: nowrap; }
 .comment-content { max-width: 300px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .text-muted { color: var(--color-text-muted); font-size: 13px; }
 


### PR DESCRIPTION
Fixes #8

## Summary
- 后端 Comment 实体添加 `articleTitle` 虚拟字段
- 使用 `JOIN FETCH` 查询避免 N+1 性能问题
- 后台留言管理表格新增"文章"列，可直观区分留言来源