### PR TITLE
Fix #10: 留言管理展示的文章列是空的

### DIFF
--- a/blog-backend/src/main/java/com/blog/entity/Comment.java
+++ b/blog-backend/src/main/java/com/blog/entity/Comment.java
@@ -50,8 +50,12 @@ public class Comment {
     public Article getArticle() { return article; }
     public void setArticle(Article article) { this.article = article; }
     public Long getArticleId() { return articleId; }
+
     @Transient
-    public String getArticleTitle() { return article != null ? article.getTitle() : null; }
+    private String articleTitle;
+
+    public String getArticleTitle() { return articleTitle; }
+    public void setArticleTitle(String articleTitle) { this.articleTitle = articleTitle; }
     public Boolean getVisible() { return visible; }
     public void setVisible(Boolean visible) { this.visible = visible; }
     public LocalDateTime getCreatedAt() { return createdAt; }

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -23,8 +23,15 @@ public class CommentService {
         return commentRepository.findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(articleId);
     }
 
+    @Transactional(readOnly = true)
     public List<Comment> findAll() {
-        return commentRepository.findAllWithArticle();
+        List<Comment> comments = commentRepository.findAllWithArticle();
+        for (Comment c : comments) {
+            if (c.getArticle() != null) {
+                c.setArticleTitle(c.getArticle().getTitle());
+            }
+        }
+        return comments;
     }
 
     @Transactional


### PR DESCRIPTION
Fixes #10

## Summary
- 将 `articleTitle` 从 getter 计算改为显式 `@Transient` 字段
- 在 `CommentService.findAll()` 中事务内显式设置 `articleTitle`
- 确保 JSON 序列化时文章标题正确返回

## Test plan
- [ ] 后台留言管理页面文章列正确显示文章标题