### PR TITLE
Fix #12: 文章留言缺少分页

### DIFF
--- a/blog-backend/src/main/java/com/blog/controller/CommentController.java
+++ b/blog-backend/src/main/java/com/blog/controller/CommentController.java
@@ -4,6 +4,9 @@ import com.blog.dto.CommentDTO;
 import com.blog.entity.Comment;
 import com.blog.service.CommentService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,8 +21,11 @@ public class CommentController {
     }
 
     @GetMapping("/api/articles/{articleId}/comments")
-    public List<Comment> list(@PathVariable Long articleId) {
-        return commentService.findByArticleId(articleId);
+    public Page<Comment> list(@PathVariable Long articleId,
+                              @RequestParam(defaultValue = "0") int page,
+                              @RequestParam(defaultValue = "10") int size) {
+        return commentService.findByArticleId(articleId,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
     }
 
     @PostMapping("/api/articles/{articleId}/comments")

--- a/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
+++ b/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package com.blog.repository;
 
 import com.blog.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -9,6 +11,7 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleIdOrderByCreatedAtDesc(Long articleId);
     List<Comment> findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(Long articleId);
+    Page<Comment> findByArticleIdAndVisibleTrue(Long articleId, Pageable pageable);
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.article ORDER BY c.createdAt DESC")
     List<Comment> findAllWithArticle();

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -4,6 +4,8 @@ import com.blog.dto.CommentDTO;
 import com.blog.entity.Article;
 import com.blog.entity.Comment;
 import com.blog.repository.CommentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,10 @@ public class CommentService {
 
     public List<Comment> findByArticleId(Long articleId) {
         return commentRepository.findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(articleId);
+    }
+
+    public Page<Comment> findByArticleId(Long articleId, Pageable pageable) {
+        return commentRepository.findByArticleIdAndVisibleTrue(articleId, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/blog-frontend/src/views/ArticleDetail.vue
+++ b/blog-frontend/src/views/ArticleDetail.vue
@@ -14,7 +14,7 @@
 
     <!-- 评论区 -->
     <section class="comments-section">
-      <h2 class="comments-title">评论 ({{ comments.length }})</h2>
+      <h2 class="comments-title">评论 ({{ commentTotal }})</h2>
 
       <!-- 评论表单 -->
       <form class="comment-form card" @submit.prevent="submitComment">
@@ -50,6 +50,8 @@
       <div v-else class="no-comments">
         <p>暂无评论，来发表第一条评论吧</p>
       </div>
+
+      <Pagination :currentPage="commentPage" :totalPages="commentTotalPages" @change="onCommentPageChange" />
     </section>
 
     <footer class="article-footer">
@@ -71,10 +73,14 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import MarkdownIt from 'markdown-it'
 import api from '../api'
+import Pagination from '../components/Pagination.vue'
 
 const route = useRoute()
 const article = ref(null)
 const comments = ref([])
+const commentPage = ref(0)
+const commentTotalPages = ref(0)
+const commentTotal = ref(0)
 const submitting = ref(false)
 const commentForm = ref({ nickname: '', email: '', content: '' })
 const commentError = ref('')
@@ -91,8 +97,17 @@ function formatDate(dt) {
 }
 
 async function loadComments() {
-  const { data } = await api.get(`/articles/${route.params.id}/comments`)
-  comments.value = data
+  const { data } = await api.get(`/articles/${route.params.id}/comments`, {
+    params: { page: commentPage.value, size: 10 }
+  })
+  comments.value = data.content
+  commentTotalPages.value = data.totalPages
+  commentTotal.value = data.totalElements
+}
+
+function onCommentPageChange(p) {
+  commentPage.value = p
+  loadComments()
 }
 
 async function submitComment() {
@@ -102,6 +117,7 @@ async function submitComment() {
   try {
     await api.post(`/articles/${route.params.id}/comments`, commentForm.value)
     commentForm.value = { nickname: commentForm.value.nickname, email: commentForm.value.email, content: '' }
+    commentPage.value = 0
     await loadComments()
   } catch (err) {
     commentError.value = err.response?.data?.message || '评论提交失败，请稍后再试'


### PR DESCRIPTION
Fixes #12

## Summary
- 后端评论列表接口改为 `Page<Comment>` 分页查询，每页 10 条
- 前端评论区添加分页组件，复用已有 `Pagination` 组件
- 提交新评论后自动回到第一页