### PR TITLE
Fix #12: 修复文章留言不显示及分页问题

### DIFF
--- a/blog-backend/src/main/java/com/blog/entity/Comment.java
+++ b/blog-backend/src/main/java/com/blog/entity/Comment.java
@@ -28,7 +28,7 @@ public class Comment {
     @Column(name = "article_id", insertable = false, updatable = false)
     private Long articleId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
     private Boolean visible = true;
 
     @Column(name = "created_at")

--- a/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
+++ b/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
@@ -10,8 +10,11 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByArticleIdOrderByCreatedAtDesc(Long articleId);
-    List<Comment> findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(Long articleId);
-    Page<Comment> findByArticleIdAndVisibleTrue(Long articleId, Pageable pageable);
+    @Query("SELECT c FROM Comment c WHERE c.articleId = :articleId AND (c.visible = true OR c.visible IS NULL) ORDER BY c.createdAt DESC")
+    List<Comment> findVisibleByArticleId(Long articleId);
+
+    @Query("SELECT c FROM Comment c WHERE c.articleId = :articleId AND (c.visible = true OR c.visible IS NULL)")
+    Page<Comment> findVisibleByArticleId(Long articleId, Pageable pageable);
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.article ORDER BY c.createdAt DESC")
     List<Comment> findAllWithArticle();

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -22,11 +22,11 @@ public class CommentService {
     }
 
     public List<Comment> findByArticleId(Long articleId) {
-        return commentRepository.findByArticleIdAndVisibleTrueOrderByCreatedAtDesc(articleId);
+        return commentRepository.findVisibleByArticleId(articleId);
     }
 
     public Page<Comment> findByArticleId(Long articleId, Pageable pageable) {
-        return commentRepository.findByArticleIdAndVisibleTrue(articleId, pageable);
+        return commentRepository.findVisibleByArticleId(articleId, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/blog-frontend/src/views/ArticleDetail.vue
+++ b/blog-frontend/src/views/ArticleDetail.vue
@@ -100,9 +100,10 @@ async function loadComments() {
   const { data } = await api.get(`/articles/${route.params.id}/comments`, {
     params: { page: commentPage.value, size: 10 }
   })
-  comments.value = data.content
-  commentTotalPages.value = data.totalPages
-  commentTotal.value = data.totalElements
+  comments.value = data.content || []
+  const pg = data.page || data
+  commentTotalPages.value = pg.totalPages || 0
+  commentTotal.value = pg.totalElements || 0
 }
 
 function onCommentPageChange(p) {


### PR DESCRIPTION
Fixes #12

## Summary
- 根因：添加 `visible` 字段后，旧评论数据 `visible` 列为 NULL，查询 `visible=true` 匹配不到
- 改用 JPQL 查询，条件 `visible = true OR visible IS NULL`，兼容旧数据
- Comment 实体 `visible` 列添加 `DEFAULT TRUE` 数据库默认值
- 前端兼容 Spring Boot 3.2 的 Page JSON 格式

## Test plan
- [ ] 已有旧评论正常显示
- [ ] 分页正常工作（每页 10 条）
- [ ] 新提交评论正常显示