### PR TITLE
Fix #13: 后台管理所有表格需分页

### DIFF
--- a/blog-backend/src/main/java/com/blog/controller/CategoryController.java
+++ b/blog-backend/src/main/java/com/blog/controller/CategoryController.java
@@ -2,6 +2,9 @@ package com.blog.controller;
 
 import com.blog.entity.Category;
 import com.blog.service.CategoryService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +22,12 @@ public class CategoryController {
     @GetMapping("/categories")
     public List<Category> list() {
         return categoryService.findAll();
+    }
+
+    @GetMapping("/admin/categories")
+    public Page<Category> listPaged(@RequestParam(defaultValue = "0") int page,
+                                    @RequestParam(defaultValue = "10") int size) {
+        return categoryService.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
     }
 
     @PostMapping("/admin/categories")

--- a/blog-backend/src/main/java/com/blog/controller/CommentController.java
+++ b/blog-backend/src/main/java/com/blog/controller/CommentController.java
@@ -36,8 +36,9 @@ public class CommentController {
     }
 
     @GetMapping("/api/admin/comments")
-    public List<Comment> listAll() {
-        return commentService.findAll();
+    public Page<Comment> listAll(@RequestParam(defaultValue = "0") int page,
+                                 @RequestParam(defaultValue = "10") int size) {
+        return commentService.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
     }
 
     @PutMapping("/api/admin/comments/{id}/toggle-visible")

--- a/blog-backend/src/main/java/com/blog/controller/TagController.java
+++ b/blog-backend/src/main/java/com/blog/controller/TagController.java
@@ -2,6 +2,9 @@ package com.blog.controller;
 
 import com.blog.entity.Tag;
 import com.blog.service.TagService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +22,12 @@ public class TagController {
     @GetMapping("/tags")
     public List<Tag> list() {
         return tagService.findAll();
+    }
+
+    @GetMapping("/admin/tags")
+    public Page<Tag> listPaged(@RequestParam(defaultValue = "0") int page,
+                               @RequestParam(defaultValue = "10") int size) {
+        return tagService.findAll(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt")));
     }
 
     @PostMapping("/admin/tags")

--- a/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
+++ b/blog-backend/src/main/java/com/blog/repository/CommentRepository.java
@@ -18,4 +18,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Query("SELECT c FROM Comment c JOIN FETCH c.article ORDER BY c.createdAt DESC")
     List<Comment> findAllWithArticle();
+
+    @Query(value = "SELECT c FROM Comment c JOIN FETCH c.article",
+           countQuery = "SELECT COUNT(c) FROM Comment c")
+    Page<Comment> findAllWithArticle(Pageable pageable);
 }

--- a/blog-backend/src/main/java/com/blog/service/CategoryService.java
+++ b/blog-backend/src/main/java/com/blog/service/CategoryService.java
@@ -2,6 +2,8 @@ package com.blog.service;
 
 import com.blog.entity.Category;
 import com.blog.repository.CategoryRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,6 +18,10 @@ public class CategoryService {
 
     public List<Category> findAll() {
         return categoryRepository.findAll();
+    }
+
+    public Page<Category> findAll(Pageable pageable) {
+        return categoryRepository.findAll(pageable);
     }
 
     public Category findById(Long id) {

--- a/blog-backend/src/main/java/com/blog/service/CommentService.java
+++ b/blog-backend/src/main/java/com/blog/service/CommentService.java
@@ -40,6 +40,17 @@ public class CommentService {
         return comments;
     }
 
+    @Transactional(readOnly = true)
+    public Page<Comment> findAll(Pageable pageable) {
+        Page<Comment> page = commentRepository.findAllWithArticle(pageable);
+        for (Comment c : page.getContent()) {
+            if (c.getArticle() != null) {
+                c.setArticleTitle(c.getArticle().getTitle());
+            }
+        }
+        return page;
+    }
+
     @Transactional
     public Comment toggleVisible(Long id) {
         Comment comment = commentRepository.findById(id).orElseThrow();

--- a/blog-backend/src/main/java/com/blog/service/TagService.java
+++ b/blog-backend/src/main/java/com/blog/service/TagService.java
@@ -2,6 +2,8 @@ package com.blog.service;
 
 import com.blog.entity.Tag;
 import com.blog.repository.TagRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -18,6 +20,10 @@ public class TagService {
 
     public List<Tag> findAll() {
         return tagRepository.findAll();
+    }
+
+    public Page<Tag> findAll(Pageable pageable) {
+        return tagRepository.findAll(pageable);
     }
 
     public Tag findById(Long id) {

--- a/blog-frontend/src/views/admin/CategoryList.vue
+++ b/blog-frontend/src/views/admin/CategoryList.vue
@@ -44,21 +44,27 @@
         </tbody>
       </table>
     </div>
+
+    <Pagination :currentPage="page" :totalPages="totalPages" @change="page = $event; loadCategories()" />
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import api from '../../api'
+import Pagination from '../../components/Pagination.vue'
 
 const categories = ref([])
+const page = ref(0)
+const totalPages = ref(0)
 const newName = ref('')
 const editId = ref(null)
 const editName = ref('')
 
 async function loadCategories() {
-  const { data } = await api.get('/categories')
-  categories.value = data
+  const { data } = await api.get('/admin/categories', { params: { page: page.value, size: 10 } })
+  categories.value = data.content
+  totalPages.value = data.totalPages
 }
 
 async function handleAdd() {

--- a/blog-frontend/src/views/admin/CommentList.vue
+++ b/blog-frontend/src/views/admin/CommentList.vue
@@ -42,18 +42,24 @@
         </tbody>
       </table>
     </div>
+
+    <Pagination :currentPage="page" :totalPages="totalPages" @change="page = $event; loadComments()" />
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import api from '../../api'
+import Pagination from '../../components/Pagination.vue'
 
 const comments = ref([])
+const page = ref(0)
+const totalPages = ref(0)
 
 async function loadComments() {
-  const { data } = await api.get('/admin/comments')
-  comments.value = data
+  const { data } = await api.get('/admin/comments', { params: { page: page.value, size: 10 } })
+  comments.value = data.content
+  totalPages.value = data.totalPages
 }
 
 async function handleToggle(id) {

--- a/blog-frontend/src/views/admin/TagList.vue
+++ b/blog-frontend/src/views/admin/TagList.vue
@@ -44,21 +44,27 @@
         </tbody>
       </table>
     </div>
+
+    <Pagination :currentPage="page" :totalPages="totalPages" @change="page = $event; loadTags()" />
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
 import api from '../../api'
+import Pagination from '../../components/Pagination.vue'
 
 const tags = ref([])
+const page = ref(0)
+const totalPages = ref(0)
 const newName = ref('')
 const editId = ref(null)
 const editName = ref('')
 
 async function loadTags() {
-  const { data } = await api.get('/tags')
-  tags.value = data
+  const { data } = await api.get('/admin/tags', { params: { page: page.value, size: 10 } })
+  tags.value = data.content
+  totalPages.value = data.totalPages
 }
 
 async function handleAdd() {


### PR DESCRIPTION
Fixes #13

## Summary
- 分类管理、标签管理、留言管理后台表格全部添加分页功能
- 后端新增分页查询接口，每页 10 条
- 前端复用 Pagination 组件

## Test plan
- [ ] 分类管理分页正常
- [ ] 标签管理分页正常
- [ ] 留言管理分页正常，文章标题列正常显示