### PR TITLE
Fix #13: 后台管理表格分页数据不显示

### DIFF
--- a/blog-frontend/src/views/admin/ArticleList.vue
+++ b/blog-frontend/src/views/admin/ArticleList.vue
@@ -58,8 +58,9 @@ const totalPages = ref(0)
 
 async function loadArticles() {
   const { data } = await api.get('/admin/articles', { params: { page: page.value, size: 10 } })
-  articles.value = data.content
-  totalPages.value = data.totalPages
+  articles.value = data.content || data || []
+  const pg = data.page || data
+  totalPages.value = pg.totalPages || 0
 }
 
 async function handleDelete(id) {

--- a/blog-frontend/src/views/admin/CategoryList.vue
+++ b/blog-frontend/src/views/admin/CategoryList.vue
@@ -63,8 +63,9 @@ const editName = ref('')
 
 async function loadCategories() {
   const { data } = await api.get('/admin/categories', { params: { page: page.value, size: 10 } })
-  categories.value = data.content
-  totalPages.value = data.totalPages
+  categories.value = data.content || data || []
+  const pg = data.page || data
+  totalPages.value = pg.totalPages || 0
 }
 
 async function handleAdd() {

--- a/blog-frontend/src/views/admin/CommentList.vue
+++ b/blog-frontend/src/views/admin/CommentList.vue
@@ -58,8 +58,9 @@ const totalPages = ref(0)
 
 async function loadComments() {
   const { data } = await api.get('/admin/comments', { params: { page: page.value, size: 10 } })
-  comments.value = data.content
-  totalPages.value = data.totalPages
+  comments.value = data.content || data || []
+  const pg = data.page || data
+  totalPages.value = pg.totalPages || 0
 }
 
 async function handleToggle(id) {

--- a/blog-frontend/src/views/admin/TagList.vue
+++ b/blog-frontend/src/views/admin/TagList.vue
@@ -63,8 +63,9 @@ const editName = ref('')
 
 async function loadTags() {
   const { data } = await api.get('/admin/tags', { params: { page: page.value, size: 10 } })
-  tags.value = data.content
-  totalPages.value = data.totalPages
+  tags.value = data.content || data || []
+  const pg = data.page || data
+  totalPages.value = pg.totalPages || 0
 }
 
 async function handleAdd() {


### PR DESCRIPTION
Fixes #13

## Summary
- 所有后台管理列表页（文章、分类、标签、留言）兼容 Spring Boot 3.2 Page 序列化格式
- 同时支持 `data.totalPages`（旧格式）和 `data.page.totalPages`（新格式）
- 添加 fallback：`data.content || data || []` 防止数据为空导致页面空白

## Test plan
- [ ] 文章管理分页正常显示
- [ ] 分类管理数据和分页正常显示
- [ ] 标签管理数据和分页正常显示
- [ ] 留言管理数据和分页正常显示