### PR TITLE
feat: add Android native app (blog-android) with Jetpack Compose

### DIFF
--- a/blog-android/app/build.gradle.kts
+++ b/blog-android/app/build.gradle.kts
@@ -1,0 +1,95 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.hilt.android)
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.blog.android"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.blog.android"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0.0"
+
+        buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8080\"")
+        buildConfigField("String", "API_BASE_URL", "\"http://10.0.2.2:8080/api\"")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+            buildConfigField("String", "BASE_URL", "\"https://your-server.com\"")
+            buildConfigField("String", "API_BASE_URL", "\"https://your-server.com/api\"")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.core.ktx)
+    implementation(libs.lifecycle.runtime.ktx)
+    implementation(libs.lifecycle.viewmodel.compose)
+    implementation(libs.lifecycle.runtime.compose)
+    implementation(libs.activity.compose)
+
+    implementation(platform(libs.compose.bom))
+    implementation(libs.compose.ui)
+    implementation(libs.compose.ui.graphics)
+    implementation(libs.compose.ui.tooling.preview)
+    implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons)
+    debugImplementation(libs.compose.ui.tooling)
+
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.compiler)
+    implementation(libs.hilt.navigation.compose)
+
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.gson)
+    implementation(libs.okhttp.logging)
+
+    implementation(libs.security.crypto)
+
+    implementation(libs.markwon.core)
+    implementation(libs.markwon.html)
+    implementation(libs.markwon.image.coil)
+    implementation(libs.coil.compose)
+
+    implementation(libs.navigation.compose)
+}
+
+kapt {
+    correctErrorTypes = true
+}

--- a/blog-android/app/proguard-rules.pro
+++ b/blog-android/app/proguard-rules.pro
@@ -1,0 +1,17 @@
+# Retrofit
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class com.blog.android.model.** { *; }
+
+# Gson
+-keep class com.google.gson.** { *; }
+-keepclassmembers class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# OkHttp
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# Hilt
+-keep class dagger.hilt.** { *; }

--- a/blog-android/app/src/main/AndroidManifest.xml
+++ b/blog-android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".BlogApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.BlogApp"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.BlogApp">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/blog-android/app/src/main/java/com/blog/android/BlogApplication.kt
+++ b/blog-android/app/src/main/java/com/blog/android/BlogApplication.kt
@@ -1,0 +1,7 @@
+package com.blog.android
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class BlogApplication : Application()

--- a/blog-android/app/src/main/java/com/blog/android/MainActivity.kt
+++ b/blog-android/app/src/main/java/com/blog/android/MainActivity.kt
@@ -1,0 +1,22 @@
+package com.blog.android
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import com.blog.android.ui.BlogApp
+import com.blog.android.ui.theme.BlogTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            BlogTheme {
+                BlogApp()
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/config/AppConfig.kt
+++ b/blog-android/app/src/main/java/com/blog/android/config/AppConfig.kt
@@ -1,0 +1,10 @@
+package com.blog.android.config
+
+import com.blog.android.BuildConfig
+
+object AppConfig {
+    val BASE_URL: String = BuildConfig.BASE_URL
+    val API_BASE_URL: String = BuildConfig.API_BASE_URL
+    const val PAGE_SIZE = 10
+    const val MAX_PAGE_SIZE = 100
+}

--- a/blog-android/app/src/main/java/com/blog/android/di/NetworkModule.kt
+++ b/blog-android/app/src/main/java/com/blog/android/di/NetworkModule.kt
@@ -1,0 +1,49 @@
+package com.blog.android.di
+
+import com.blog.android.config.AppConfig
+import com.blog.android.network.ApiService
+import com.blog.android.network.AuthInterceptor
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient {
+        return OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            })
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(10, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(AppConfig.API_BASE_URL + "/")
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideApiService(retrofit: Retrofit): ApiService {
+        return retrofit.create(ApiService::class.java)
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/model/Models.kt
+++ b/blog-android/app/src/main/java/com/blog/android/model/Models.kt
@@ -1,0 +1,89 @@
+package com.blog.android.model
+
+import com.google.gson.annotations.SerializedName
+
+data class Article(
+    val id: Long,
+    val title: String,
+    val content: String? = null,
+    val summary: String? = null,
+    val coverImage: String? = null,
+    val status: ArticleStatus,
+    val category: Category? = null,
+    val tags: List<Tag> = emptyList(),
+    val createdAt: String,
+    val updatedAt: String? = null
+)
+
+enum class ArticleStatus {
+    DRAFT, PUBLISHED;
+
+    val displayName: String
+        get() = when (this) {
+            DRAFT -> "草稿"
+            PUBLISHED -> "已发布"
+        }
+}
+
+data class Category(
+    val id: Long,
+    val name: String,
+    val createdAt: String? = null
+)
+
+data class Tag(
+    val id: Long,
+    val name: String,
+    val createdAt: String? = null
+)
+
+data class Comment(
+    val id: Long,
+    val nickname: String,
+    val email: String? = null,
+    val content: String,
+    val articleId: Long,
+    val articleTitle: String? = null,
+    val visible: Boolean,
+    val createdAt: String
+)
+
+data class PageResponse<T>(
+    val content: List<T>,
+    val totalElements: Int,
+    val totalPages: Int,
+    val number: Int,
+    val size: Int,
+    val first: Boolean,
+    val last: Boolean
+)
+
+data class ArticleRequest(
+    val title: String,
+    val content: String,
+    val summary: String,
+    val coverImage: String? = null,
+    val status: ArticleStatus,
+    val categoryId: Long? = null,
+    val tagIds: List<Long> = emptyList()
+)
+
+data class CommentRequest(
+    val nickname: String,
+    val email: String? = null,
+    val content: String
+)
+
+data class LoginRequest(
+    val username: String,
+    val password: String
+)
+
+data class LoginResponse(
+    val token: String,
+    val nickname: String
+)
+
+data class UploadResponse(
+    val url: String
+)

--- a/blog-android/app/src/main/java/com/blog/android/network/ApiService.kt
+++ b/blog-android/app/src/main/java/com/blog/android/network/ApiService.kt
@@ -1,0 +1,109 @@
+package com.blog.android.network
+
+import com.blog.android.model.*
+import okhttp3.MultipartBody
+import retrofit2.http.*
+
+interface ApiService {
+    // Public
+    @GET("articles")
+    suspend fun getArticles(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10
+    ): PageResponse<Article>
+
+    @GET("articles/{id}")
+    suspend fun getArticle(@Path("id") id: Long): Article
+
+    @GET("articles/{articleId}/comments")
+    suspend fun getComments(
+        @Path("articleId") articleId: Long,
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10
+    ): PageResponse<Comment>
+
+    @POST("articles/{articleId}/comments")
+    suspend fun postComment(
+        @Path("articleId") articleId: Long,
+        @Body body: CommentRequest
+    ): Comment
+
+    @GET("categories")
+    suspend fun getCategories(): List<Category>
+
+    @GET("tags")
+    suspend fun getTags(): List<Tag>
+
+    // Auth
+    @POST("auth/login")
+    suspend fun login(@Body body: LoginRequest): LoginResponse
+
+    // Admin Articles
+    @GET("admin/articles")
+    suspend fun adminGetArticles(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10
+    ): PageResponse<Article>
+
+    @GET("admin/articles/{id}")
+    suspend fun adminGetArticle(@Path("id") id: Long): Article
+
+    @POST("admin/articles")
+    suspend fun adminCreateArticle(@Body body: ArticleRequest): Article
+
+    @PUT("admin/articles/{id}")
+    suspend fun adminUpdateArticle(@Path("id") id: Long, @Body body: ArticleRequest): Article
+
+    @DELETE("admin/articles/{id}")
+    suspend fun adminDeleteArticle(@Path("id") id: Long)
+
+    // Admin Categories
+    @GET("admin/categories")
+    suspend fun adminGetCategories(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 100
+    ): PageResponse<Category>
+
+    @POST("admin/categories")
+    suspend fun adminCreateCategory(@Body body: Map<String, String>): Category
+
+    @PUT("admin/categories/{id}")
+    suspend fun adminUpdateCategory(@Path("id") id: Long, @Body body: Map<String, String>): Category
+
+    @DELETE("admin/categories/{id}")
+    suspend fun adminDeleteCategory(@Path("id") id: Long)
+
+    // Admin Tags
+    @GET("admin/tags")
+    suspend fun adminGetTags(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 100
+    ): PageResponse<Tag>
+
+    @POST("admin/tags")
+    suspend fun adminCreateTag(@Body body: Map<String, String>): Tag
+
+    @PUT("admin/tags/{id}")
+    suspend fun adminUpdateTag(@Path("id") id: Long, @Body body: Map<String, String>): Tag
+
+    @DELETE("admin/tags/{id}")
+    suspend fun adminDeleteTag(@Path("id") id: Long)
+
+    // Admin Comments
+    @GET("admin/comments")
+    suspend fun adminGetComments(
+        @Query("page") page: Int = 0,
+        @Query("size") size: Int = 10
+    ): PageResponse<Comment>
+
+    @PUT("admin/comments/{id}/toggle-visible")
+    suspend fun adminToggleComment(@Path("id") id: Long): Comment
+
+    @DELETE("admin/comments/{id}")
+    suspend fun adminDeleteComment(@Path("id") id: Long)
+
+    // Upload
+    @Multipart
+    @POST("admin/upload")
+    suspend fun uploadImage(@Part file: MultipartBody.Part): UploadResponse
+}

--- a/blog-android/app/src/main/java/com/blog/android/network/AuthInterceptor.kt
+++ b/blog-android/app/src/main/java/com/blog/android/network/AuthInterceptor.kt
@@ -1,0 +1,26 @@
+package com.blog.android.network
+
+import com.blog.android.security.TokenManager
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    private val tokenManager: TokenManager
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request().newBuilder()
+
+        tokenManager.getToken()?.let { token ->
+            request.addHeader("Authorization", "Bearer $token")
+        }
+
+        val response = chain.proceed(request.build())
+
+        if (response.code == 401) {
+            tokenManager.clearAll()
+        }
+
+        return response
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/repository/ArticleRepository.kt
+++ b/blog-android/app/src/main/java/com/blog/android/repository/ArticleRepository.kt
@@ -1,0 +1,48 @@
+package com.blog.android.repository
+
+import com.blog.android.model.*
+import com.blog.android.network.ApiService
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ArticleRepository @Inject constructor(private val api: ApiService) {
+    suspend fun getArticles(page: Int, size: Int = 10) = api.getArticles(page, size)
+    suspend fun getArticle(id: Long) = api.getArticle(id)
+    suspend fun getComments(articleId: Long, page: Int) = api.getComments(articleId, page)
+    suspend fun postComment(articleId: Long, request: CommentRequest) = api.postComment(articleId, request)
+    suspend fun getCategories() = api.getCategories()
+    suspend fun getTags() = api.getTags()
+
+    // Admin
+    suspend fun adminGetArticles(page: Int, size: Int = 10) = api.adminGetArticles(page, size)
+    suspend fun adminGetArticle(id: Long) = api.adminGetArticle(id)
+    suspend fun adminCreateArticle(request: ArticleRequest) = api.adminCreateArticle(request)
+    suspend fun adminUpdateArticle(id: Long, request: ArticleRequest) = api.adminUpdateArticle(id, request)
+    suspend fun adminDeleteArticle(id: Long) = api.adminDeleteArticle(id)
+
+    suspend fun adminGetCategories(page: Int = 0, size: Int = 100) = api.adminGetCategories(page, size)
+    suspend fun adminCreateCategory(name: String) = api.adminCreateCategory(mapOf("name" to name))
+    suspend fun adminUpdateCategory(id: Long, name: String) = api.adminUpdateCategory(id, mapOf("name" to name))
+    suspend fun adminDeleteCategory(id: Long) = api.adminDeleteCategory(id)
+
+    suspend fun adminGetTags(page: Int = 0, size: Int = 100) = api.adminGetTags(page, size)
+    suspend fun adminCreateTag(name: String) = api.adminCreateTag(mapOf("name" to name))
+    suspend fun adminUpdateTag(id: Long, name: String) = api.adminUpdateTag(id, mapOf("name" to name))
+    suspend fun adminDeleteTag(id: Long) = api.adminDeleteTag(id)
+
+    suspend fun adminGetComments(page: Int) = api.adminGetComments(page)
+    suspend fun adminToggleComment(id: Long) = api.adminToggleComment(id)
+    suspend fun adminDeleteComment(id: Long) = api.adminDeleteComment(id)
+
+    suspend fun uploadImage(imageData: ByteArray, filename: String, mimeType: String): UploadResponse {
+        val requestBody = imageData.toRequestBody(mimeType.toMediaTypeOrNull())
+        val part = MultipartBody.Part.createFormData("file", filename, requestBody)
+        return api.uploadImage(part)
+    }
+
+    suspend fun login(request: LoginRequest) = api.login(request)
+}

--- a/blog-android/app/src/main/java/com/blog/android/security/TokenManager.kt
+++ b/blog-android/app/src/main/java/com/blog/android/security/TokenManager.kt
@@ -1,0 +1,46 @@
+package com.blog.android.security
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenManager @Inject constructor(
+    @ApplicationContext context: Context
+) {
+    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    private val prefs = EncryptedSharedPreferences.create(
+        "blog_secure_prefs",
+        masterKeyAlias,
+        context,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun saveToken(token: String) {
+        prefs.edit().putString(KEY_TOKEN, token).apply()
+    }
+
+    fun getToken(): String? = prefs.getString(KEY_TOKEN, null)
+
+    fun saveNickname(nickname: String) {
+        prefs.edit().putString(KEY_NICKNAME, nickname).apply()
+    }
+
+    fun getNickname(): String? = prefs.getString(KEY_NICKNAME, null)
+
+    fun clearAll() {
+        prefs.edit().clear().apply()
+    }
+
+    fun isLoggedIn(): Boolean = getToken() != null
+
+    companion object {
+        private const val KEY_TOKEN = "jwt_token"
+        private const val KEY_NICKNAME = "user_nickname"
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/BlogApp.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/BlogApp.kt
@@ -1,0 +1,143 @@
+package com.blog.android.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import com.blog.android.ui.screen.*
+import com.blog.android.ui.screen.admin.*
+import com.blog.android.ui.theme.BlogPrimary
+import com.blog.android.ui.theme.BlogSurface
+import com.blog.android.viewmodel.AuthViewModel
+
+sealed class Screen(val route: String) {
+    data object Articles : Screen("articles")
+    data object ArticleDetail : Screen("articles/{id}") {
+        fun createRoute(id: Long) = "articles/$id"
+    }
+    data object Login : Screen("login")
+    data object AdminArticles : Screen("admin/articles")
+    data object AdminArticleNew : Screen("admin/articles/new")
+    data object AdminArticleEdit : Screen("admin/articles/{id}/edit") {
+        fun createRoute(id: Long) = "admin/articles/$id/edit"
+    }
+    data object AdminCategories : Screen("admin/categories")
+    data object AdminTags : Screen("admin/tags")
+    data object AdminComments : Screen("admin/comments")
+}
+
+@Composable
+fun BlogApp() {
+    val navController = rememberNavController()
+    val authViewModel: AuthViewModel = hiltViewModel()
+    val isLoggedIn by authViewModel.isLoggedIn.collectAsState()
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentBackStackEntry?.destination?.route
+
+    val isAdminRoute = currentRoute?.startsWith("admin") == true
+
+    data class BottomNavItem(val route: String, val icon: @Composable () -> Unit, val label: String)
+
+    val publicItems = listOf(
+        BottomNavItem("articles", { Icon(Icons.Default.Home, contentDescription = null) }, "首页")
+    )
+    val authItem = if (isLoggedIn) {
+        BottomNavItem("admin/articles", { Icon(Icons.Default.Dashboard, contentDescription = null) }, "管理")
+    } else {
+        BottomNavItem("login", { Icon(Icons.Default.Person, contentDescription = null) }, "登录")
+    }
+    val adminItems = listOf(
+        BottomNavItem("admin/articles", { Icon(Icons.Default.Article, contentDescription = null) }, "文章"),
+        BottomNavItem("admin/categories", { Icon(Icons.Default.Folder, contentDescription = null) }, "分类"),
+        BottomNavItem("admin/tags", { Icon(Icons.Default.Tag, contentDescription = null) }, "标签"),
+        BottomNavItem("admin/comments", { Icon(Icons.Default.Chat, contentDescription = null) }, "评论")
+    )
+
+    val bottomNavItems = if (isAdminRoute && isLoggedIn) {
+        adminItems + BottomNavItem("articles", { Icon(Icons.Default.Home, contentDescription = null) }, "首页")
+    } else {
+        publicItems + authItem
+    }
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar(containerColor = BlogSurface) {
+                bottomNavItems.forEach { item ->
+                    NavigationBarItem(
+                        icon = item.icon,
+                        label = { Text(item.label, fontSize = 11.sp) },
+                        selected = currentRoute == item.route,
+                        onClick = {
+                            if (currentRoute != item.route) {
+                                navController.navigate(item.route) {
+                                    popUpTo(navController.graph.startDestinationId) { saveState = true }
+                                    launchSingleTop = true
+                                    restoreState = true
+                                }
+                            }
+                        },
+                        colors = NavigationBarItemDefaults.colors(
+                            selectedIconColor = BlogPrimary,
+                            selectedTextColor = BlogPrimary
+                        )
+                    )
+                }
+            }
+        }
+    ) { padding ->
+        NavHost(
+            navController = navController,
+            startDestination = Screen.Articles.route,
+            modifier = Modifier.padding(padding)
+        ) {
+            composable(Screen.Articles.route) {
+                ArticleListScreen(
+                    onArticleClick = { id -> navController.navigate(Screen.ArticleDetail.createRoute(id)) }
+                )
+            }
+            composable(
+                Screen.ArticleDetail.route,
+                arguments = listOf(navArgument("id") { type = NavType.LongType })
+            ) {
+                ArticleDetailScreen(onBack = { navController.popBackStack() })
+            }
+            composable(Screen.Login.route) {
+                LoginScreen(viewModel = authViewModel)
+            }
+            composable(Screen.AdminArticles.route) {
+                AdminArticleListScreen(
+                    onNewArticle = { navController.navigate(Screen.AdminArticleNew.route) },
+                    onEditArticle = { id -> navController.navigate(Screen.AdminArticleEdit.createRoute(id)) }
+                )
+            }
+            composable(Screen.AdminArticleNew.route) {
+                AdminArticleEditScreen(onBack = { navController.popBackStack() })
+            }
+            composable(
+                Screen.AdminArticleEdit.route,
+                arguments = listOf(navArgument("id") { type = NavType.LongType })
+            ) {
+                AdminArticleEditScreen(onBack = { navController.popBackStack() })
+            }
+            composable(Screen.AdminCategories.route) {
+                AdminCategoryScreen()
+            }
+            composable(Screen.AdminTags.route) {
+                AdminTagScreen()
+            }
+            composable(Screen.AdminComments.route) {
+                AdminCommentScreen()
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/components/ArticleCard.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/components/ArticleCard.kt
@@ -1,0 +1,82 @@
+package com.blog.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.blog.android.model.Article
+import com.blog.android.ui.theme.*
+
+@Composable
+fun ArticleCard(article: Article, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .shadow(elevation = 2.dp, shape = RoundedCornerShape(12.dp))
+            .background(BlogSurface)
+            .border(1.dp, BlogBorder.copy(alpha = 0.5f), RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        // Meta row
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            article.category?.let { CategoryBadge(it.name) }
+            Text(
+                text = article.createdAt.take(10),
+                fontSize = 12.sp,
+                color = BlogTextMuted
+            )
+        }
+
+        // Title
+        Text(
+            text = article.title,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Serif,
+            color = BlogText,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        // Summary
+        article.summary?.takeIf { it.isNotEmpty() }?.let {
+            Text(
+                text = it,
+                fontSize = 15.sp,
+                color = BlogTextSecondary,
+                lineHeight = 24.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // Tags
+        if (article.tags.isNotEmpty()) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                article.tags.forEach { tag -> TagChip(tag.name) }
+            }
+        }
+
+        // Read more
+        Text(
+            text = "阅读全文 \u2192",
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
+            color = BlogPrimary
+        )
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/components/CommonComponents.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/components/CommonComponents.kt
@@ -1,0 +1,111 @@
+package com.blog.android.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.blog.android.model.ArticleStatus
+import com.blog.android.ui.theme.*
+
+@Composable
+fun CategoryBadge(name: String) {
+    Text(
+        text = name.uppercase(),
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = BlogPrimary,
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(BlogPrimaryLight)
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    )
+}
+
+@Composable
+fun TagChip(name: String) {
+    Text(
+        text = "# $name",
+        fontSize = 12.sp,
+        color = BlogTextMuted
+    )
+}
+
+@Composable
+fun StatusBadge(status: ArticleStatus) {
+    val bgColor = if (status == ArticleStatus.PUBLISHED) PublishedBg else DraftBg
+    val textColor = if (status == ArticleStatus.PUBLISHED) PublishedText else DraftText
+    Text(
+        text = status.displayName,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = textColor,
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(bgColor)
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    )
+}
+
+@Composable
+fun LoadingView(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(color = BlogPrimary)
+            Spacer(modifier = Modifier.height(12.dp))
+            Text("加载中...", fontSize = 13.sp, color = BlogTextMuted)
+        }
+    }
+}
+
+@Composable
+fun ErrorView(message: String, onRetry: (() -> Unit)? = null) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(message, color = BlogTextSecondary)
+            onRetry?.let {
+                Spacer(modifier = Modifier.height(12.dp))
+                TextButton(onClick = it) {
+                    Text("重试", color = BlogPrimary)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun PaginationBar(
+    currentPage: Int,
+    totalPages: Int,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit
+) {
+    if (totalPages <= 1) return
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TextButton(onClick = onPrevious, enabled = currentPage > 0) {
+            Text("上一页")
+        }
+        Text(
+            "${currentPage + 1} / $totalPages",
+            fontSize = 13.sp,
+            color = BlogTextSecondary,
+            modifier = Modifier.padding(horizontal = 16.dp)
+        )
+        TextButton(onClick = onNext, enabled = currentPage + 1 < totalPages) {
+            Text("下一页")
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/components/MarkdownText.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/components/MarkdownText.kt
@@ -1,0 +1,34 @@
+package com.blog.android.ui.components
+
+import android.widget.TextView
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import io.noties.markwon.Markwon
+import io.noties.markwon.html.HtmlPlugin
+
+@Composable
+fun MarkdownText(markdown: String, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val markwon = remember {
+        Markwon.builder(context)
+            .usePlugin(HtmlPlugin.create())
+            .build()
+    }
+
+    AndroidView(
+        factory = { ctx ->
+            TextView(ctx).apply {
+                textSize = 16f
+                setLineSpacing(0f, 1.6f)
+                setTextColor(0xFF1A1A2E.toInt())
+            }
+        },
+        update = { textView ->
+            markwon.setMarkdown(textView, markdown)
+        },
+        modifier = modifier
+    )
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/ArticleDetailScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/ArticleDetailScreen.kt
@@ -1,0 +1,228 @@
+package com.blog.android.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.*
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.ArticleDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ArticleDetailScreen(
+    viewModel: ArticleDetailViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val article by viewModel.article.collectAsState()
+    val comments by viewModel.comments.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    val isSubmittingComment by viewModel.isSubmittingComment.collectAsState()
+    val commentError by viewModel.commentError.collectAsState()
+
+    var nickname by remember { mutableStateOf("") }
+    var email by remember { mutableStateOf("") }
+    var commentContent by remember { mutableStateOf("") }
+
+    LaunchedEffect(Unit) {
+        viewModel.loadArticle()
+        viewModel.loadComments()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("文章详情", fontSize = 16.sp) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = BlogSurface
+                )
+            )
+        }
+    ) { padding ->
+        when {
+            isLoading -> LoadingView(modifier = Modifier.padding(padding))
+            errorMessage != null -> ErrorView(errorMessage!!) { viewModel.loadArticle() }
+            article != null -> {
+                val art = article!!
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .background(BlogBackground),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    // Header
+                    item {
+                        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                art.category?.let { CategoryBadge(it.name) }
+                                Text(art.createdAt.take(10), fontSize = 12.sp, color = BlogTextMuted)
+                            }
+                            Text(
+                                art.title,
+                                fontSize = 24.sp,
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.Serif,
+                                color = BlogText
+                            )
+                            if (art.tags.isNotEmpty()) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    art.tags.forEach { TagChip(it.name) }
+                                }
+                            }
+                            HorizontalDivider(color = BlogBorder)
+                        }
+                    }
+
+                    // Content
+                    item {
+                        art.content?.let {
+                            MarkdownText(
+                                markdown = it,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp)
+                            )
+                        }
+                    }
+
+                    // Comments section
+                    item {
+                        HorizontalDivider(color = BlogBorder)
+                        Spacer(Modifier.height(16.dp))
+                        Text(
+                            "评论 (${comments.size})",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            fontFamily = FontFamily.Serif,
+                            color = BlogText
+                        )
+                    }
+
+                    // Comment form
+                    item {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(BlogSurface, RoundedCornerShape(10.dp))
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                OutlinedTextField(
+                                    value = nickname,
+                                    onValueChange = { nickname = it },
+                                    label = { Text("昵称 *") },
+                                    singleLine = true,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                OutlinedTextField(
+                                    value = email,
+                                    onValueChange = { email = it },
+                                    label = { Text("邮箱") },
+                                    singleLine = true,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+                            OutlinedTextField(
+                                value = commentContent,
+                                onValueChange = { commentContent = it },
+                                label = { Text("写下你的评论...") },
+                                minLines = 3,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            commentError?.let {
+                                Text(it, fontSize = 12.sp, color = BlogDanger)
+                            }
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                Button(
+                                    onClick = {
+                                        viewModel.submitComment(
+                                            nickname,
+                                            email.ifEmpty { null },
+                                            commentContent
+                                        ) { commentContent = "" }
+                                    },
+                                    enabled = nickname.isNotEmpty() && commentContent.isNotEmpty() && !isSubmittingComment,
+                                    colors = ButtonDefaults.buttonColors(containerColor = BlogPrimary)
+                                ) {
+                                    if (isSubmittingComment) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(16.dp),
+                                            color = BlogSurface,
+                                            strokeWidth = 2.dp
+                                        )
+                                    } else {
+                                        Text("提交评论")
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Comment list
+                    if (comments.isEmpty()) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 20.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text("暂无评论", color = BlogTextMuted)
+                            }
+                        }
+                    } else {
+                        items(comments, key = { it.id }) { comment ->
+                            Column(modifier = Modifier.padding(vertical = 10.dp)) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Text(
+                                        comment.nickname,
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        color = BlogText
+                                    )
+                                    Text(
+                                        comment.createdAt.take(10),
+                                        fontSize = 12.sp,
+                                        color = BlogTextMuted
+                                    )
+                                }
+                                Spacer(Modifier.height(6.dp))
+                                Text(comment.content, fontSize = 15.sp, color = BlogTextSecondary)
+                                Spacer(Modifier.height(10.dp))
+                                HorizontalDivider(color = BlogBorderLight)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val RoundedCornerShape = androidx.compose.foundation.shape.RoundedCornerShape

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/ArticleListScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/ArticleListScreen.kt
@@ -1,0 +1,105 @@
+package com.blog.android.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.*
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.ArticleListViewModel
+
+@Composable
+fun ArticleListScreen(
+    viewModel: ArticleListViewModel = hiltViewModel(),
+    onArticleClick: (Long) -> Unit
+) {
+    val articles by viewModel.articles.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    val currentPage by viewModel.currentPage.collectAsState()
+    val totalPages by viewModel.totalPages.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (articles.isEmpty()) viewModel.loadArticles()
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BlogBackground),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Header
+        item {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    "最新文章",
+                    fontSize = 28.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Serif,
+                    color = BlogText
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    "思考、记录与分享",
+                    fontSize = 15.sp,
+                    color = BlogTextSecondary
+                )
+            }
+        }
+
+        when {
+            isLoading && articles.isEmpty() -> {
+                item { LoadingView(modifier = Modifier.height(300.dp)) }
+            }
+            errorMessage != null && articles.isEmpty() -> {
+                item {
+                    ErrorView(errorMessage!!) { viewModel.loadArticles() }
+                }
+            }
+            articles.isEmpty() -> {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(200.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("暂无文章", color = BlogTextMuted)
+                    }
+                }
+            }
+            else -> {
+                items(articles, key = { it.id }) { article ->
+                    ArticleCard(article = article) {
+                        onArticleClick(article.id)
+                    }
+                }
+                item {
+                    PaginationBar(currentPage, totalPages,
+                        onPrevious = { viewModel.previousPage() },
+                        onNext = { viewModel.nextPage() }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/LoginScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/LoginScreen.kt
@@ -1,0 +1,118 @@
+package com.blog.android.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AuthViewModel
+
+@Composable
+fun LoginScreen(viewModel: AuthViewModel) {
+    val isLoading by viewModel.isLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BlogBackground)
+            .padding(32.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 400.dp)
+                .shadow(20.dp, RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(16.dp))
+                .background(BlogSurface)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Icon
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(BlogPrimaryLight),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Default.Lock,
+                    contentDescription = null,
+                    tint = BlogPrimary,
+                    modifier = Modifier.size(24.dp)
+                )
+            }
+
+            Text("Welcome Back", fontSize = 24.sp, fontWeight = FontWeight.Bold, color = BlogText)
+            Text("登录管理后台", fontSize = 15.sp, color = BlogTextSecondary)
+
+            errorMessage?.let {
+                Text(
+                    it,
+                    fontSize = 13.sp,
+                    color = BlogDanger,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(HiddenBg)
+                        .border(1.dp, BlogDanger.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+                        .padding(12.dp)
+                )
+            }
+
+            OutlinedTextField(
+                value = username,
+                onValueChange = { username = it },
+                label = { Text("用户名") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            OutlinedTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = { Text("密码") },
+                singleLine = true,
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Button(
+                onClick = { viewModel.login(username, password) },
+                enabled = username.isNotEmpty() && password.isNotEmpty() && !isLoading,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = BlogPrimary),
+                shape = RoundedCornerShape(8.dp)
+            ) {
+                if (isLoading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        color = BlogSurface,
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("登录", fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+                }
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminArticleEditScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminArticleEditScreen.kt
@@ -1,0 +1,265 @@
+package com.blog.android.ui.screen.admin
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.model.ArticleStatus
+import com.blog.android.ui.components.LoadingView
+import com.blog.android.ui.components.MarkdownText
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AdminArticleEditViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AdminArticleEditScreen(
+    viewModel: AdminArticleEditViewModel = hiltViewModel(),
+    onBack: () -> Unit
+) {
+    val title by viewModel.title.collectAsState()
+    val content by viewModel.content.collectAsState()
+    val summary by viewModel.summary.collectAsState()
+    val status by viewModel.status.collectAsState()
+    val selectedCategoryId by viewModel.selectedCategoryId.collectAsState()
+    val selectedTagIds by viewModel.selectedTagIds.collectAsState()
+    val categories by viewModel.categories.collectAsState()
+    val tags by viewModel.tags.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val isSaving by viewModel.isSaving.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+    val isPreviewMode by viewModel.isPreviewMode.collectAsState()
+
+    val context = LocalContext.current
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        uri?.let {
+            val inputStream = context.contentResolver.openInputStream(it)
+            val bytes = inputStream?.readBytes() ?: return@let
+            inputStream.close()
+            val mimeType = context.contentResolver.getType(it) ?: "image/jpeg"
+            viewModel.uploadImage(bytes, "photo.jpg", mimeType)
+        }
+    }
+
+    LaunchedEffect(Unit) { viewModel.loadData() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(if (viewModel.articleId != null) "编辑文章" else "新建文章", fontSize = 16.sp) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    TextButton(
+                        onClick = { viewModel.save { onBack() } },
+                        enabled = title.isNotEmpty() && !isSaving
+                    ) {
+                        if (isSaving) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                        } else {
+                            Text("保存", fontWeight = FontWeight.SemiBold, color = BlogPrimary)
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = BlogSurface)
+            )
+        }
+    ) { padding ->
+        if (isLoading) {
+            LoadingView(modifier = Modifier.padding(padding))
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .background(BlogBackground),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                // Title
+                item {
+                    OutlinedTextField(
+                        value = title,
+                        onValueChange = { viewModel.title.value = it },
+                        placeholder = { Text("文章标题") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                // Summary
+                item {
+                    OutlinedTextField(
+                        value = summary,
+                        onValueChange = { viewModel.summary.value = it },
+                        placeholder = { Text("文章摘要") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+
+                // Editor tabs
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(BlogSurface)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(BlogBorderLight)
+                                .padding(4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            TextButton(onClick = { viewModel.isPreviewMode.value = false }) {
+                                Text(
+                                    "编写",
+                                    color = if (!isPreviewMode) BlogPrimary else BlogTextSecondary,
+                                    fontWeight = if (!isPreviewMode) FontWeight.SemiBold else FontWeight.Normal
+                                )
+                            }
+                            TextButton(onClick = { viewModel.isPreviewMode.value = true }) {
+                                Text(
+                                    "预览",
+                                    color = if (isPreviewMode) BlogPrimary else BlogTextSecondary,
+                                    fontWeight = if (isPreviewMode) FontWeight.SemiBold else FontWeight.Normal
+                                )
+                            }
+                            Spacer(Modifier.weight(1f))
+                            IconButton(onClick = { imagePicker.launch("image/*") }) {
+                                Icon(Icons.Default.Image, contentDescription = "上传图片", tint = BlogTextSecondary)
+                            }
+                        }
+                        HorizontalDivider(color = BlogBorder)
+
+                        if (isPreviewMode) {
+                            MarkdownText(
+                                markdown = content,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = 300.dp)
+                                    .padding(12.dp)
+                            )
+                        } else {
+                            OutlinedTextField(
+                                value = content,
+                                onValueChange = { viewModel.content.value = it },
+                                placeholder = { Text("使用 Markdown 编写文章内容...") },
+                                minLines = 15,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(4.dp),
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    unfocusedBorderColor = BlogBorder.copy(alpha = 0f),
+                                    focusedBorderColor = BlogBorder.copy(alpha = 0f)
+                                )
+                            )
+                        }
+                    }
+                }
+
+                // Settings
+                item {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(BlogSurface)
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text("发布设置", fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+
+                        // Status
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            FilterChip(
+                                selected = status == ArticleStatus.DRAFT,
+                                onClick = { viewModel.status.value = ArticleStatus.DRAFT },
+                                label = { Text("草稿") }
+                            )
+                            FilterChip(
+                                selected = status == ArticleStatus.PUBLISHED,
+                                onClick = { viewModel.status.value = ArticleStatus.PUBLISHED },
+                                label = { Text("发布") }
+                            )
+                        }
+
+                        // Category
+                        var categoryExpanded by remember { mutableStateOf(false) }
+                        ExposedDropdownMenuBox(
+                            expanded = categoryExpanded,
+                            onExpandedChange = { categoryExpanded = it }
+                        ) {
+                            OutlinedTextField(
+                                value = categories.find { it.id == selectedCategoryId }?.name ?: "无分类",
+                                onValueChange = {},
+                                readOnly = true,
+                                label = { Text("分类") },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = categoryExpanded) },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .menuAnchor()
+                            )
+                            ExposedDropdownMenu(
+                                expanded = categoryExpanded,
+                                onDismissRequest = { categoryExpanded = false }
+                            ) {
+                                DropdownMenuItem(
+                                    text = { Text("无分类") },
+                                    onClick = {
+                                        viewModel.selectedCategoryId.value = null
+                                        categoryExpanded = false
+                                    }
+                                )
+                                categories.forEach { cat ->
+                                    DropdownMenuItem(
+                                        text = { Text(cat.name) },
+                                        onClick = {
+                                            viewModel.selectedCategoryId.value = cat.id
+                                            categoryExpanded = false
+                                        }
+                                    )
+                                }
+                            }
+                        }
+
+                        // Tags
+                        Text("标签", fontSize = 14.sp, fontWeight = FontWeight.Medium, color = BlogTextSecondary)
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            tags.forEach { tag ->
+                                FilterChip(
+                                    selected = selectedTagIds.contains(tag.id),
+                                    onClick = { viewModel.toggleTag(tag.id) },
+                                    label = { Text(tag.name) }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                errorMessage?.let {
+                    item { Text(it, fontSize = 12.sp, color = BlogDanger) }
+                }
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminArticleListScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminArticleListScreen.kt
@@ -1,0 +1,121 @@
+package com.blog.android.ui.screen.admin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.*
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AdminArticleListViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminArticleListScreen(
+    viewModel: AdminArticleListViewModel = hiltViewModel(),
+    onNewArticle: () -> Unit,
+    onEditArticle: (Long) -> Unit
+) {
+    val articles by viewModel.articles.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val currentPage by viewModel.currentPage.collectAsState()
+    val totalPages by viewModel.totalPages.collectAsState()
+
+    var deleteTarget by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (articles.isEmpty()) viewModel.loadArticles()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("文章管理") },
+                actions = {
+                    IconButton(onClick = onNewArticle) {
+                        Icon(Icons.Default.Add, contentDescription = "新建文章")
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = BlogSurface)
+            )
+        }
+    ) { padding ->
+        if (isLoading && articles.isEmpty()) {
+            LoadingView(modifier = Modifier.padding(padding))
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .background(BlogBackground)
+            ) {
+                items(articles, key = { it.id }) { article ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BlogSurface)
+                            .clickable { onEditArticle(article.id) }
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                article.title,
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(Modifier.height(6.dp))
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                StatusBadge(article.status)
+                                article.category?.let {
+                                    Text(it.name, fontSize = 12.sp, color = BlogTextSecondary)
+                                }
+                                Text(article.createdAt.take(10), fontSize = 12.sp, color = BlogTextMuted)
+                            }
+                        }
+                        IconButton(onClick = { deleteTarget = article.id }) {
+                            Icon(Icons.Default.Delete, contentDescription = "删除", tint = BlogDanger)
+                        }
+                    }
+                    HorizontalDivider(color = BlogBorderLight)
+                }
+                item {
+                    PaginationBar(currentPage, totalPages,
+                        onPrevious = { viewModel.previousPage() },
+                        onNext = { viewModel.nextPage() }
+                    )
+                }
+            }
+        }
+    }
+
+    deleteTarget?.let { id ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("确认删除") },
+            text = { Text("删除后无法恢复，确定要删除这篇文章吗？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteArticle(id)
+                    deleteTarget = null
+                }) { Text("删除", color = BlogDanger) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("取消") }
+            }
+        )
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminCategoryScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminCategoryScreen.kt
@@ -1,0 +1,139 @@
+package com.blog.android.ui.screen.admin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.LoadingView
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AdminCategoryViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminCategoryScreen(viewModel: AdminCategoryViewModel = hiltViewModel()) {
+    val categories by viewModel.categories.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    var newName by remember { mutableStateOf("") }
+    var editingId by remember { mutableStateOf<Long?>(null) }
+    var editingName by remember { mutableStateOf("") }
+    var deleteTarget by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (categories.isEmpty()) viewModel.loadCategories()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("分类管理") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = BlogSurface)
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(BlogBackground)
+        ) {
+            // Add bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BlogSurface)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    placeholder = { Text("新建分类名称") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                Button(
+                    onClick = {
+                        viewModel.createCategory(newName) { newName = "" }
+                    },
+                    enabled = newName.isNotEmpty(),
+                    colors = ButtonDefaults.buttonColors(containerColor = BlogPrimary)
+                ) { Text("添加") }
+            }
+
+            HorizontalDivider(color = BlogBorder)
+
+            if (isLoading && categories.isEmpty()) {
+                LoadingView()
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(categories, key = { it.id }) { category ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(BlogSurface)
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (editingId == category.id) {
+                                OutlinedTextField(
+                                    value = editingName,
+                                    onValueChange = { editingName = it },
+                                    singleLine = true,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                TextButton(onClick = {
+                                    viewModel.updateCategory(category.id, editingName) { editingId = null }
+                                }) { Text("保存") }
+                                TextButton(onClick = { editingId = null }) { Text("取消") }
+                            } else {
+                                Text(category.name, fontSize = 15.sp, modifier = Modifier.weight(1f))
+                                category.createdAt?.let {
+                                    Text(it.take(10), fontSize = 12.sp, color = BlogTextMuted)
+                                }
+                                IconButton(onClick = {
+                                    editingId = category.id
+                                    editingName = category.name
+                                }) {
+                                    Icon(Icons.Default.Edit, contentDescription = "编辑", tint = BlogPrimary)
+                                }
+                                IconButton(onClick = { deleteTarget = category.id }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "删除", tint = BlogDanger)
+                                }
+                            }
+                        }
+                        HorizontalDivider(color = BlogBorderLight)
+                    }
+                }
+            }
+        }
+    }
+
+    deleteTarget?.let { id ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("确认删除") },
+            text = { Text("确定要删除此分类吗？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteCategory(id)
+                    deleteTarget = null
+                }) { Text("删除", color = BlogDanger) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("取消") }
+            }
+        )
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminCommentScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminCommentScreen.kt
@@ -1,0 +1,132 @@
+package com.blog.android.ui.screen.admin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.LoadingView
+import com.blog.android.ui.components.PaginationBar
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AdminCommentViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminCommentScreen(viewModel: AdminCommentViewModel = hiltViewModel()) {
+    val comments by viewModel.comments.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val currentPage by viewModel.currentPage.collectAsState()
+    val totalPages by viewModel.totalPages.collectAsState()
+
+    var deleteTarget by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (comments.isEmpty()) viewModel.loadComments()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("评论管理") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = BlogSurface)
+            )
+        }
+    ) { padding ->
+        if (isLoading && comments.isEmpty()) {
+            LoadingView(modifier = Modifier.padding(padding))
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .background(BlogBackground)
+            ) {
+                items(comments, key = { it.id }) { comment ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(BlogSurface)
+                            .alpha(if (comment.visible) 1f else 0.6f)
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(comment.nickname, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+                            Text(
+                                if (comment.visible) "展示中" else "已隐藏",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = if (comment.visible) VisibleText else HiddenText,
+                                modifier = Modifier
+                                    .background(
+                                        if (comment.visible) VisibleBg else HiddenBg,
+                                        shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp)
+                                    )
+                                    .padding(horizontal = 8.dp, vertical = 3.dp)
+                            )
+                        }
+                        comment.articleTitle?.let {
+                            Text(it, fontSize = 12.sp, color = BlogTextSecondary, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                        Text(comment.content, fontSize = 14.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(comment.createdAt.take(10), fontSize = 12.sp, color = BlogTextMuted)
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                TextButton(onClick = { viewModel.toggleVisible(comment.id) }) {
+                                    Text(
+                                        if (comment.visible) "隐藏" else "展示",
+                                        fontSize = 13.sp,
+                                        color = BlogPrimary
+                                    )
+                                }
+                                IconButton(onClick = { deleteTarget = comment.id }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "删除", tint = BlogDanger, modifier = Modifier.size(18.dp))
+                                }
+                            }
+                        }
+                    }
+                    HorizontalDivider(color = BlogBorderLight)
+                }
+                item {
+                    PaginationBar(currentPage, totalPages,
+                        onPrevious = { viewModel.previousPage() },
+                        onNext = { viewModel.nextPage() }
+                    )
+                }
+            }
+        }
+    }
+
+    deleteTarget?.let { id ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("确认删除") },
+            text = { Text("确定要删除此评论吗？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteComment(id)
+                    deleteTarget = null
+                }) { Text("删除", color = BlogDanger) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("取消") }
+            }
+        )
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminTagScreen.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/screen/admin/AdminTagScreen.kt
@@ -1,0 +1,136 @@
+package com.blog.android.ui.screen.admin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.blog.android.ui.components.LoadingView
+import com.blog.android.ui.theme.*
+import com.blog.android.viewmodel.AdminTagViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AdminTagScreen(viewModel: AdminTagViewModel = hiltViewModel()) {
+    val tags by viewModel.tags.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    var newName by remember { mutableStateOf("") }
+    var editingId by remember { mutableStateOf<Long?>(null) }
+    var editingName by remember { mutableStateOf("") }
+    var deleteTarget by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(Unit) {
+        if (tags.isEmpty()) viewModel.loadTags()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("标签管理") },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = BlogSurface)
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(BlogBackground)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(BlogSurface)
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    placeholder = { Text("新建标签名称") },
+                    singleLine = true,
+                    modifier = Modifier.weight(1f)
+                )
+                Button(
+                    onClick = { viewModel.createTag(newName) { newName = "" } },
+                    enabled = newName.isNotEmpty(),
+                    colors = ButtonDefaults.buttonColors(containerColor = BlogPrimary)
+                ) { Text("添加") }
+            }
+
+            HorizontalDivider(color = BlogBorder)
+
+            if (isLoading && tags.isEmpty()) {
+                LoadingView()
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(tags, key = { it.id }) { tag ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(BlogSurface)
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (editingId == tag.id) {
+                                OutlinedTextField(
+                                    value = editingName,
+                                    onValueChange = { editingName = it },
+                                    singleLine = true,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                TextButton(onClick = {
+                                    viewModel.updateTag(tag.id, editingName) { editingId = null }
+                                }) { Text("保存") }
+                                TextButton(onClick = { editingId = null }) { Text("取消") }
+                            } else {
+                                Text(tag.name, fontSize = 15.sp, modifier = Modifier.weight(1f))
+                                tag.createdAt?.let {
+                                    Text(it.take(10), fontSize = 12.sp, color = BlogTextMuted)
+                                }
+                                IconButton(onClick = {
+                                    editingId = tag.id
+                                    editingName = tag.name
+                                }) {
+                                    Icon(Icons.Default.Edit, contentDescription = "编辑", tint = BlogPrimary)
+                                }
+                                IconButton(onClick = { deleteTarget = tag.id }) {
+                                    Icon(Icons.Default.Delete, contentDescription = "删除", tint = BlogDanger)
+                                }
+                            }
+                        }
+                        HorizontalDivider(color = BlogBorderLight)
+                    }
+                }
+            }
+        }
+    }
+
+    deleteTarget?.let { id ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text("确认删除") },
+            text = { Text("确定要删除此标签吗？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteTag(id)
+                    deleteTarget = null
+                }) { Text("删除", color = BlogDanger) }
+            },
+            dismissButton = {
+                TextButton(onClick = { deleteTarget = null }) { Text("取消") }
+            }
+        )
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/ui/theme/Color.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/theme/Color.kt
@@ -1,0 +1,27 @@
+package com.blog.android.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val BlogBackground = Color(0xFFEEECE2)
+val BlogSurface = Color.White
+val BlogPrimary = Color(0xFF2563EB)
+val BlogPrimaryHover = Color(0xFF1D4ED8)
+val BlogPrimaryLight = Color(0xFFEFF6FF)
+val BlogText = Color(0xFF1A1A2E)
+val BlogTextSecondary = Color(0xFF6B7280)
+val BlogTextMuted = Color(0xFF9CA3AF)
+val BlogBorder = Color(0xFFE5E7EB)
+val BlogBorderLight = Color(0xFFF3F4F6)
+val BlogSuccess = Color(0xFF10B981)
+val BlogWarning = Color(0xFFF59E0B)
+val BlogDanger = Color(0xFFEF4444)
+
+// Status colors
+val PublishedBg = Color(0xFFECFDF5)
+val PublishedText = Color(0xFF059669)
+val DraftBg = Color(0xFFFFFBEB)
+val DraftText = Color(0xFFD97706)
+val VisibleBg = Color(0xFFDCFCE7)
+val VisibleText = Color(0xFF166534)
+val HiddenBg = Color(0xFFFEE2E2)
+val HiddenText = Color(0xFF991B1B)

--- a/blog-android/app/src/main/java/com/blog/android/ui/theme/Theme.kt
+++ b/blog-android/app/src/main/java/com/blog/android/ui/theme/Theme.kt
@@ -1,0 +1,26 @@
+package com.blog.android.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val LightColorScheme = lightColorScheme(
+    primary = BlogPrimary,
+    onPrimary = BlogSurface,
+    surface = BlogSurface,
+    onSurface = BlogText,
+    background = BlogBackground,
+    onBackground = BlogText,
+    error = BlogDanger,
+    outline = BlogBorder,
+    surfaceVariant = BlogBorderLight,
+    onSurfaceVariant = BlogTextSecondary
+)
+
+@Composable
+fun BlogTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = LightColorScheme,
+        content = content
+    )
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminArticleEditViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminArticleEditViewModel.kt
@@ -1,0 +1,120 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.config.AppConfig
+import com.blog.android.model.*
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminArticleEditViewModel @Inject constructor(
+    private val repository: ArticleRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    val articleId: Long? = savedStateHandle.get<Long>("id")
+
+    val title = MutableStateFlow("")
+    val content = MutableStateFlow("")
+    val summary = MutableStateFlow("")
+    val coverImage = MutableStateFlow<String?>(null)
+    val status = MutableStateFlow(ArticleStatus.DRAFT)
+    val selectedCategoryId = MutableStateFlow<Long?>(null)
+    val selectedTagIds = MutableStateFlow<Set<Long>>(emptySet())
+
+    private val _categories = MutableStateFlow<List<Category>>(emptyList())
+    val categories: StateFlow<List<Category>> = _categories
+
+    private val _tags = MutableStateFlow<List<Tag>>(emptyList())
+    val tags: StateFlow<List<Tag>> = _tags
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _isSaving = MutableStateFlow(false)
+    val isSaving: StateFlow<Boolean> = _isSaving
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    val isPreviewMode = MutableStateFlow(false)
+
+    fun loadData() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                val catResponse = repository.adminGetCategories()
+                _categories.value = catResponse.content
+                val tagResponse = repository.adminGetTags()
+                _tags.value = tagResponse.content
+            } catch (_: Exception) {}
+
+            articleId?.let { id ->
+                try {
+                    val article = repository.adminGetArticle(id)
+                    title.value = article.title
+                    content.value = article.content ?: ""
+                    summary.value = article.summary ?: ""
+                    coverImage.value = article.coverImage
+                    status.value = article.status
+                    selectedCategoryId.value = article.category?.id
+                    selectedTagIds.value = article.tags.map { it.id }.toSet()
+                } catch (e: Exception) {
+                    _errorMessage.value = e.message
+                }
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun save(onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            _isSaving.value = true
+            _errorMessage.value = null
+            val request = ArticleRequest(
+                title = title.value,
+                content = content.value,
+                summary = summary.value,
+                coverImage = coverImage.value,
+                status = status.value,
+                categoryId = selectedCategoryId.value,
+                tagIds = selectedTagIds.value.toList()
+            )
+            try {
+                if (articleId != null) {
+                    repository.adminUpdateArticle(articleId, request)
+                } else {
+                    repository.adminCreateArticle(request)
+                }
+                onSuccess()
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isSaving.value = false
+        }
+    }
+
+    fun uploadImage(imageData: ByteArray, filename: String, mimeType: String) {
+        viewModelScope.launch {
+            try {
+                val response = repository.uploadImage(imageData, filename, mimeType)
+                val imageUrl = AppConfig.BASE_URL + response.url
+                content.value += "\n![image]($imageUrl)\n"
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun toggleTag(tagId: Long) {
+        val current = selectedTagIds.value.toMutableSet()
+        if (current.contains(tagId)) current.remove(tagId) else current.add(tagId)
+        selectedTagIds.value = current
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminArticleListViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminArticleListViewModel.kt
@@ -1,0 +1,67 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Article
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminArticleListViewModel @Inject constructor(
+    private val repository: ArticleRepository
+) : ViewModel() {
+
+    private val _articles = MutableStateFlow<List<Article>>(emptyList())
+    val articles: StateFlow<List<Article>> = _articles
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    private val _currentPage = MutableStateFlow(0)
+    val currentPage: StateFlow<Int> = _currentPage
+
+    private val _totalPages = MutableStateFlow(0)
+    val totalPages: StateFlow<Int> = _totalPages
+
+    fun loadArticles(page: Int = 0) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+            try {
+                val response = repository.adminGetArticles(page)
+                _articles.value = response.content
+                _currentPage.value = response.number
+                _totalPages.value = response.totalPages
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun deleteArticle(id: Long) {
+        viewModelScope.launch {
+            try {
+                repository.adminDeleteArticle(id)
+                _articles.value = _articles.value.filter { it.id != id }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun nextPage() {
+        if (_currentPage.value + 1 < _totalPages.value) loadArticles(_currentPage.value + 1)
+    }
+
+    fun previousPage() {
+        if (_currentPage.value > 0) loadArticles(_currentPage.value - 1)
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminCategoryViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminCategoryViewModel.kt
@@ -1,0 +1,73 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Category
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminCategoryViewModel @Inject constructor(
+    private val repository: ArticleRepository
+) : ViewModel() {
+
+    private val _categories = MutableStateFlow<List<Category>>(emptyList())
+    val categories: StateFlow<List<Category>> = _categories
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    fun loadCategories() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _categories.value = repository.adminGetCategories().content
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun createCategory(name: String, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                repository.adminCreateCategory(name)
+                loadCategories()
+                onSuccess()
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun updateCategory(id: Long, name: String, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                repository.adminUpdateCategory(id, name)
+                loadCategories()
+                onSuccess()
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun deleteCategory(id: Long) {
+        viewModelScope.launch {
+            try {
+                repository.adminDeleteCategory(id)
+                _categories.value = _categories.value.filter { it.id != id }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminCommentViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminCommentViewModel.kt
@@ -1,0 +1,77 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Comment
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminCommentViewModel @Inject constructor(
+    private val repository: ArticleRepository
+) : ViewModel() {
+
+    private val _comments = MutableStateFlow<List<Comment>>(emptyList())
+    val comments: StateFlow<List<Comment>> = _comments
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    private val _currentPage = MutableStateFlow(0)
+    val currentPage: StateFlow<Int> = _currentPage
+
+    private val _totalPages = MutableStateFlow(0)
+    val totalPages: StateFlow<Int> = _totalPages
+
+    fun loadComments(page: Int = 0) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                val response = repository.adminGetComments(page)
+                _comments.value = response.content
+                _currentPage.value = response.number
+                _totalPages.value = response.totalPages
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun toggleVisible(id: Long) {
+        viewModelScope.launch {
+            try {
+                val updated = repository.adminToggleComment(id)
+                _comments.value = _comments.value.map { if (it.id == id) updated else it }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun deleteComment(id: Long) {
+        viewModelScope.launch {
+            try {
+                repository.adminDeleteComment(id)
+                _comments.value = _comments.value.filter { it.id != id }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun nextPage() {
+        if (_currentPage.value + 1 < _totalPages.value) loadComments(_currentPage.value + 1)
+    }
+
+    fun previousPage() {
+        if (_currentPage.value > 0) loadComments(_currentPage.value - 1)
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminTagViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AdminTagViewModel.kt
@@ -1,0 +1,73 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Tag
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminTagViewModel @Inject constructor(
+    private val repository: ArticleRepository
+) : ViewModel() {
+
+    private val _tags = MutableStateFlow<List<Tag>>(emptyList())
+    val tags: StateFlow<List<Tag>> = _tags
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    fun loadTags() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            try {
+                _tags.value = repository.adminGetTags().content
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun createTag(name: String, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                repository.adminCreateTag(name)
+                loadTags()
+                onSuccess()
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun updateTag(id: Long, name: String, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            try {
+                repository.adminUpdateTag(id, name)
+                loadTags()
+                onSuccess()
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+
+    fun deleteTag(id: Long) {
+        viewModelScope.launch {
+            try {
+                repository.adminDeleteTag(id)
+                _tags.value = _tags.value.filter { it.id != id }
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/ArticleDetailViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/ArticleDetailViewModel.kt
@@ -1,0 +1,80 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Article
+import com.blog.android.model.Comment
+import com.blog.android.model.CommentRequest
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ArticleDetailViewModel @Inject constructor(
+    private val repository: ArticleRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    val articleId: Long = savedStateHandle.get<Long>("id") ?: 0L
+
+    private val _article = MutableStateFlow<Article?>(null)
+    val article: StateFlow<Article?> = _article
+
+    private val _comments = MutableStateFlow<List<Comment>>(emptyList())
+    val comments: StateFlow<List<Comment>> = _comments
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    private val _isSubmittingComment = MutableStateFlow(false)
+    val isSubmittingComment: StateFlow<Boolean> = _isSubmittingComment
+
+    private val _commentError = MutableStateFlow<String?>(null)
+    val commentError: StateFlow<String?> = _commentError
+
+    fun loadArticle() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+            try {
+                _article.value = repository.getArticle(articleId)
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun loadComments(page: Int = 0) {
+        viewModelScope.launch {
+            try {
+                val response = repository.getComments(articleId, page)
+                _comments.value = response.content
+            } catch (_: Exception) {
+                // Silently fail for comments
+            }
+        }
+    }
+
+    fun submitComment(nickname: String, email: String?, content: String, onSuccess: () -> Unit) {
+        viewModelScope.launch {
+            _isSubmittingComment.value = true
+            _commentError.value = null
+            try {
+                repository.postComment(articleId, CommentRequest(nickname, email, content))
+                loadComments()
+                onSuccess()
+            } catch (e: Exception) {
+                _commentError.value = e.message
+            }
+            _isSubmittingComment.value = false
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/ArticleListViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/ArticleListViewModel.kt
@@ -1,0 +1,60 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.Article
+import com.blog.android.repository.ArticleRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ArticleListViewModel @Inject constructor(
+    private val repository: ArticleRepository
+) : ViewModel() {
+
+    private val _articles = MutableStateFlow<List<Article>>(emptyList())
+    val articles: StateFlow<List<Article>> = _articles
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    private val _currentPage = MutableStateFlow(0)
+    val currentPage: StateFlow<Int> = _currentPage
+
+    private val _totalPages = MutableStateFlow(0)
+    val totalPages: StateFlow<Int> = _totalPages
+
+    fun loadArticles(page: Int = 0) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+            try {
+                val response = repository.getArticles(page)
+                _articles.value = response.content
+                _currentPage.value = response.number
+                _totalPages.value = response.totalPages
+            } catch (e: Exception) {
+                _errorMessage.value = e.message
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun nextPage() {
+        if (_currentPage.value + 1 < _totalPages.value) {
+            loadArticles(_currentPage.value + 1)
+        }
+    }
+
+    fun previousPage() {
+        if (_currentPage.value > 0) {
+            loadArticles(_currentPage.value - 1)
+        }
+    }
+}

--- a/blog-android/app/src/main/java/com/blog/android/viewmodel/AuthViewModel.kt
+++ b/blog-android/app/src/main/java/com/blog/android/viewmodel/AuthViewModel.kt
@@ -1,0 +1,54 @@
+package com.blog.android.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.blog.android.model.LoginRequest
+import com.blog.android.repository.ArticleRepository
+import com.blog.android.security.TokenManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val repository: ArticleRepository,
+    private val tokenManager: TokenManager
+) : ViewModel() {
+
+    private val _isLoggedIn = MutableStateFlow(tokenManager.isLoggedIn())
+    val isLoggedIn: StateFlow<Boolean> = _isLoggedIn
+
+    private val _nickname = MutableStateFlow(tokenManager.getNickname() ?: "")
+    val nickname: StateFlow<String> = _nickname
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorMessage = MutableStateFlow<String?>(null)
+    val errorMessage: StateFlow<String?> = _errorMessage
+
+    fun login(username: String, password: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorMessage.value = null
+            try {
+                val response = repository.login(LoginRequest(username, password))
+                tokenManager.saveToken(response.token)
+                tokenManager.saveNickname(response.nickname)
+                _nickname.value = response.nickname
+                _isLoggedIn.value = true
+            } catch (e: Exception) {
+                _errorMessage.value = "登录失败: ${e.message}"
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun logout() {
+        tokenManager.clearAll()
+        _isLoggedIn.value = false
+        _nickname.value = ""
+    }
+}

--- a/blog-android/app/src/main/res/values/strings.xml
+++ b/blog-android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Siguo Fan Blog</string>
+</resources>

--- a/blog-android/app/src/main/res/values/themes.xml
+++ b/blog-android/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.BlogApp" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:statusBarColor">#eeece2</item>
+        <item name="android:navigationBarColor">#eeece2</item>
+    </style>
+</resources>

--- a/blog-android/app/src/main/res/xml/network_security_config.xml
+++ b/blog-android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/blog-android/build.gradle.kts
+++ b/blog-android/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.google.dagger.hilt.android") version "2.50" apply false
+}

--- a/blog-android/fastlane/Fastfile
+++ b/blog-android/fastlane/Fastfile
@@ -1,0 +1,26 @@
+default_platform(:android)
+
+platform :android do
+  desc "Upload AAB to Google Play internal track"
+  lane :deploy do
+    upload_to_play_store(
+      track: 'internal',
+      aab: 'app/build/outputs/bundle/release/app-release.aab',
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+
+  desc "Promote internal to production"
+  lane :promote do
+    upload_to_play_store(
+      track: 'internal',
+      track_promote_to: 'production',
+      skip_upload_aab: true,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true
+    )
+  end
+end

--- a/blog-android/gradle.properties
+++ b/blog-android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/blog-android/gradle/libs.versions.toml
+++ b/blog-android/gradle/libs.versions.toml
@@ -1,0 +1,46 @@
+[versions]
+agp = "8.2.2"
+kotlin = "1.9.22"
+core-ktx = "1.12.0"
+lifecycle = "2.7.0"
+activity-compose = "1.8.2"
+compose-bom = "2024.02.00"
+hilt = "2.50"
+hilt-navigation = "1.1.0"
+retrofit = "2.9.0"
+okhttp = "4.12.0"
+security-crypto = "1.1.0-alpha06"
+markwon = "4.6.2"
+coil = "2.5.0"
+navigation-compose = "2.7.6"
+
+[libraries]
+core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt-navigation" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "security-crypto" }
+markwon-core = { group = "io.noties.markwon", name = "core", version.ref = "markwon" }
+markwon-html = { group = "io.noties.markwon", name = "html", version.ref = "markwon" }
+markwon-image-coil = { group = "io.noties.markwon", name = "image-coil", version.ref = "markwon" }
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }

--- a/blog-android/gradle/wrapper/gradle-wrapper.properties
+++ b/blog-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/blog-android/scripts/deploy-android.sh
+++ b/blog-android/scripts/deploy-android.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Android Google Play Deployment Script
+# Required environment variables:
+#   KEYSTORE_PATH          - Path to release keystore file
+#   KEYSTORE_PASSWORD      - Keystore password
+#   KEY_ALIAS              - Key alias name
+#   KEY_PASSWORD            - Key password
+#   GOOGLE_PLAY_JSON_KEY_PATH - Path to Google Play service account JSON key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== Android Google Play Deployment ===${NC}"
+
+# Check required env vars
+for var in KEYSTORE_PATH KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD GOOGLE_PLAY_JSON_KEY_PATH; do
+    if [ -z "${!var:-}" ]; then
+        echo -e "${RED}Error: $var is not set${NC}"
+        exit 1
+    fi
+done
+
+# Get version code from git
+VERSION_CODE=$(git rev-list --count HEAD)
+echo -e "${YELLOW}Version code: $VERSION_CODE${NC}"
+
+cd "$PROJECT_DIR"
+
+# Step 1: Build signed release AAB
+echo -e "${GREEN}[1/2] Building release AAB...${NC}"
+./gradlew :app:bundleRelease \
+    -Pandroid.injected.signing.store.file="$KEYSTORE_PATH" \
+    -Pandroid.injected.signing.store.password="$KEYSTORE_PASSWORD" \
+    -Pandroid.injected.signing.key.alias="$KEY_ALIAS" \
+    -Pandroid.injected.signing.key.password="$KEY_PASSWORD"
+
+AAB_FILE="app/build/outputs/bundle/release/app-release.aab"
+if [ ! -f "$AAB_FILE" ]; then
+    echo -e "${RED}AAB build failed${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}AAB built: $AAB_FILE${NC}"
+
+# Step 2: Upload to Google Play internal track
+echo -e "${GREEN}[2/2] Uploading to Google Play...${NC}"
+
+if command -v bundle &> /dev/null && [ -f "$PROJECT_DIR/fastlane/Fastfile" ]; then
+    cd "$PROJECT_DIR"
+    bundle exec fastlane supply \
+        --aab "$AAB_FILE" \
+        --track internal \
+        --json_key "$GOOGLE_PLAY_JSON_KEY_PATH" \
+        --package_name com.blog.android
+else
+    echo -e "${YELLOW}fastlane not found. Please install it:${NC}"
+    echo "  gem install fastlane"
+    echo ""
+    echo "Then upload manually:"
+    echo "  fastlane supply --aab $AAB_FILE --track internal --json_key \$GOOGLE_PLAY_JSON_KEY_PATH --package_name com.blog.android"
+    echo ""
+    echo "Or upload via Google Play Console: https://play.google.com/console"
+    exit 0
+fi
+
+echo ""
+echo -e "${GREEN}=== Deployment Complete ===${NC}"
+echo -e "AAB uploaded to Google Play internal track."
+echo -e "Promote to production: https://play.google.com/console"

--- a/blog-android/settings.gradle.kts
+++ b/blog-android/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "BlogApp"
+include(":app")


### PR DESCRIPTION
- MVVM + Hilt DI architecture with Kotlin and Jetpack Compose
- Public screens: article list, article detail (Markwon rendering), comments
- Admin screens: article CRUD with markdown editor, category/tag/comment management
- JWT authentication with EncryptedSharedPreferences
- Image upload support via ActivityResultContracts
- Google Play deployment script (deploy-android.sh) + Fastfile
- UI matches web frontend design (parchment theme, Material 3)
- Retrofit 2 + OkHttp 4 networking with auth interceptor

Closes partially #35